### PR TITLE
fix: address Supabase database lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Database Lint Fixes**: Addressed 30 Supabase lint warnings — optimised RLS initplan evaluation, consolidated overlapping policies, hardened function `search_path`, added 12 missing FK indexes, and dropped overly permissive anon policy on `user_preferences`
 - **CSP Tightening**: Removed `unsafe-eval` from `script-src` Content Security Policy (`unsafe-inline` retained — required by Next.js hydration)
 - **RLS Cleanup**: Removed 6 broken admin write RLS policies that checked a non-existent JWT claim; redacted internal security architecture details from public docs
 - **Rate Limiting**: Added rate limiting to `/api/search-data` public endpoint (100 req/15 min)

--- a/supabase/migrations/20260302_database_lint_fixes.sql
+++ b/supabase/migrations/20260302_database_lint_fixes.sql
@@ -1,0 +1,118 @@
+-- Database Lint Fixes
+--
+-- Addresses 30 Supabase lint warnings from issue #161:
+--   1. RLS initplan optimisation (auth.uid() wrapped in subselect)
+--   2. Overlapping policy consolidation (role scoping + drop unused)
+--   3. Function search_path hardening
+--   4. Missing FK indexes on junction tables
+--
+-- Deferred: unused index cleanup (needs production pg_stat verification)
+
+-- ============================================================================
+-- 1. RLS INITPLAN FIX — wrap auth.uid() in subselect for per-query evaluation
+-- ============================================================================
+
+-- 1a. case_studies: "Admins can manage case studies"
+--     Also fixes overlapping policy: change from `public` to `authenticated` role
+--     (anon users can never be admin, so this is semantically identical but avoids
+--     unnecessary policy evaluation for anonymous requests)
+DROP POLICY IF EXISTS "Admins can manage case studies" ON "public"."case_studies";
+CREATE POLICY "Admins can manage case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_preferences
+      WHERE user_preferences.id = (SELECT auth.uid())
+        AND user_preferences.role = 'admin'
+    )
+  );
+
+-- 1b. user_preferences: "Users can update own preferences"
+DROP POLICY IF EXISTS "Users can update own preferences" ON "public"."user_preferences";
+CREATE POLICY "Users can update own preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR UPDATE
+  TO public
+  USING ((SELECT auth.uid()) = id);
+
+-- 1c. user_preferences: "Users can view own preferences"
+DROP POLICY IF EXISTS "Users can view own preferences" ON "public"."user_preferences";
+CREATE POLICY "Users can view own preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR SELECT
+  TO public
+  USING ((SELECT auth.uid()) = id);
+
+-- ============================================================================
+-- 2. OVERLAPPING POLICY CONSOLIDATION
+-- ============================================================================
+
+-- 2a. Drop "Allow anon access to user_preferences" — anon users should not
+--     be able to read all user preferences. This was overly permissive.
+DROP POLICY IF EXISTS "Allow anon access to user_preferences" ON "public"."user_preferences";
+
+-- 2b. Scope "Admins can manage all preferences" to authenticated role
+--     (anon users can never be admin)
+DROP POLICY IF EXISTS "Admins can manage all preferences" ON "public"."user_preferences";
+CREATE POLICY "Admins can manage all preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR ALL
+  TO authenticated
+  USING (role = 'admin');
+
+-- ============================================================================
+-- 3. FUNCTION search_path HARDENING
+-- ============================================================================
+
+ALTER FUNCTION public.set_blog_posts_published_at() SET search_path = public;
+ALTER FUNCTION public.set_published_at_column() SET search_path = public;
+ALTER FUNCTION public.update_blog_posts_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_updated_at_column() SET search_path = public;
+ALTER FUNCTION public.update_ts_content() SET search_path = public;
+ALTER FUNCTION public.verify_initial_setup() SET search_path = public;
+
+-- ============================================================================
+-- 4. MISSING FK INDEXES on junction table reverse-side columns
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_blog_post_relations_related_blog_post_id
+  ON public.blog_post_relations (related_blog_post_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_industry_relations_industry_id
+  ON public.case_study_industry_relations (industry_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_partner_company_relations_partner_company_id
+  ON public.case_study_partner_company_relations (partner_company_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_persona_relations_persona_id
+  ON public.case_study_persona_relations (persona_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_quantum_company_relations_quantum_company_id
+  ON public.case_study_quantum_company_relations (quantum_company_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_quantum_hardware_relations_quantum_hardware_id
+  ON public.case_study_quantum_hardware_relations (quantum_hardware_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_quantum_software_relations_quantum_software_id
+  ON public.case_study_quantum_software_relations (quantum_software_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_relations_related_case_study_id
+  ON public.case_study_relations (related_case_study_id);
+
+CREATE INDEX IF NOT EXISTS idx_persona_algorithm_relations_algorithm_id
+  ON public.persona_algorithm_relations (algorithm_id);
+
+CREATE INDEX IF NOT EXISTS idx_quantum_company_hardware_relations_quantum_hardware_id
+  ON public.quantum_company_hardware_relations (quantum_hardware_id);
+
+CREATE INDEX IF NOT EXISTS idx_quantum_company_software_relations_quantum_software_id
+  ON public.quantum_company_software_relations (quantum_software_id);
+
+CREATE INDEX IF NOT EXISTS idx_stack_layers_parent_layer_id
+  ON public.stack_layers (parent_layer_id);

--- a/supabase/migrations/20260302_fix_overlapping_policies.sql
+++ b/supabase/migrations/20260302_fix_overlapping_policies.sql
@@ -1,0 +1,119 @@
+-- Fix Overlapping Permissive Policies
+--
+-- Splits FOR ALL admin policies into per-action policies so that no
+-- role+action combination has more than one permissive policy.
+--
+-- Before (case_studies, authenticated SELECT):
+--   "Admins can manage case studies" (ALL) + "Public can view published" (SELECT)
+--   → both evaluated, results OR'd — wasteful
+--
+-- After: each role+action has exactly one policy.
+
+-- ============================================================================
+-- 1. CASE_STUDIES — replace 3 policies with 5 non-overlapping ones
+-- ============================================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "Admins can manage case studies" ON "public"."case_studies";
+DROP POLICY IF EXISTS "Public can view published case_studies" ON "public"."case_studies";
+DROP POLICY IF EXISTS "Authenticated users can create case studies" ON "public"."case_studies";
+
+-- SELECT for anon: published only
+CREATE POLICY "Anon can view published case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR SELECT
+  TO anon
+  USING (published = true);
+
+-- SELECT for authenticated: published OR admin (single policy, no overlap)
+CREATE POLICY "Authenticated can view case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR SELECT
+  TO authenticated
+  USING (
+    published = true
+    OR EXISTS (
+      SELECT 1 FROM public.user_preferences
+      WHERE user_preferences.id = (SELECT auth.uid())
+        AND user_preferences.role = 'admin'
+    )
+  );
+
+-- INSERT for authenticated: any authenticated user (unchanged logic)
+CREATE POLICY "Authenticated users can create case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+-- UPDATE for authenticated: admins only
+CREATE POLICY "Admins can update case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_preferences
+      WHERE user_preferences.id = (SELECT auth.uid())
+        AND user_preferences.role = 'admin'
+    )
+  );
+
+-- DELETE for authenticated: admins only
+CREATE POLICY "Admins can delete case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_preferences
+      WHERE user_preferences.id = (SELECT auth.uid())
+        AND user_preferences.role = 'admin'
+    )
+  );
+
+-- ============================================================================
+-- 2. USER_PREFERENCES — replace 3 policies with 4 non-overlapping ones
+-- ============================================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "Admins can manage all preferences" ON "public"."user_preferences";
+DROP POLICY IF EXISTS "Users can view own preferences" ON "public"."user_preferences";
+DROP POLICY IF EXISTS "Users can update own preferences" ON "public"."user_preferences";
+
+-- SELECT for authenticated: own row OR admin rows
+CREATE POLICY "Authenticated can view preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = id OR role = 'admin');
+
+-- UPDATE for authenticated: own row OR admin rows
+CREATE POLICY "Authenticated can update preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR UPDATE
+  TO authenticated
+  USING ((SELECT auth.uid()) = id OR role = 'admin');
+
+-- INSERT for authenticated: admins only (user rows created via service role at signup)
+CREATE POLICY "Admins can insert preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (role = 'admin');
+
+-- DELETE for authenticated: admins only
+CREATE POLICY "Admins can delete preferences"
+  ON "public"."user_preferences"
+  AS permissive
+  FOR DELETE
+  TO authenticated
+  USING (role = 'admin');

--- a/supabase/migrations/20260302_remaining_lint_fixes.sql
+++ b/supabase/migrations/20260302_remaining_lint_fixes.sql
@@ -1,0 +1,29 @@
+-- Remaining Lint Fixes
+--
+-- 1. search_path on two missed functions
+-- 2. Tighten case_studies INSERT to admins only
+
+-- ============================================================================
+-- 1. FUNCTION search_path — missed from first migration
+-- ============================================================================
+
+ALTER FUNCTION public.create_slug(text) SET search_path = public;
+ALTER FUNCTION public.setup_admin_role(text) SET search_path = public;
+
+-- ============================================================================
+-- 2. TIGHTEN case_studies INSERT — admins only (was WITH CHECK (true))
+-- ============================================================================
+
+DROP POLICY IF EXISTS "Authenticated users can create case studies" ON "public"."case_studies";
+CREATE POLICY "Admins can create case studies"
+  ON "public"."case_studies"
+  AS permissive
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_preferences
+      WHERE user_preferences.id = (SELECT auth.uid())
+        AND user_preferences.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- Wraps `auth.uid()` in subselect for RLS initplan optimisation (3 policies)
- Splits `FOR ALL` admin policies into per-action policies to eliminate overlapping permissive policy warnings
- Tightens `case_studies` INSERT to admins only (was unrestricted for all authenticated users)
- Drops overly permissive anon SELECT on `user_preferences`
- Sets `search_path` on 8 trigger/utility functions
- Adds 12 missing FK indexes on junction table reverse-FK columns

All three migrations have been applied to the remote database and verified with `supabase db lint --linked` (no warnings remaining).

Closes #161

## Test plan
- [x] Applied migrations to remote database
- [x] `supabase db lint --linked` returns no schema errors
- [x] `npm test` passes (235 tests)