### PR TITLE
fix: patch serialize-javascript RCE (GHSA-5c6j-r48x-rmvq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **serialize-javascript RCE** ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)): Added npm override to force `serialize-javascript@7.0.3` — fixes RCE via `RegExp.flags` and `Date.prototype.toISOString()`. Transitive dep via `@sentry/nextjs → webpack → terser-webpack-plugin`. Override can be removed once `terser-webpack-plugin` bumps from `^6.0.2` to `^7.0.3`.
 - **Database Lint Fixes**: Addressed 30 Supabase lint warnings — optimised RLS initplan evaluation, consolidated overlapping policies, hardened function `search_path`, added 12 missing FK indexes, and dropped overly permissive anon policy on `user_preferences`
 - **CSP Tightening**: Removed `unsafe-eval` from `script-src` Content Security Policy (`unsafe-inline` retained — required by Next.js hydration)
 - **RLS Cleanup**: Removed 6 broken admin write RLS policies that checked a non-existent JWT claim; redacted internal security architecture details from public docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -10566,15 +10566,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -10958,26 +10949,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -11107,12 +11078,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "openqase",
   "version": "0.5.0",
   "private": true,
+  "overrides": {
+    "serialize-javascript": "7.0.3"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Adds npm override for `serialize-javascript@7.0.3` to fix high-severity RCE vulnerability ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq))
- Transitive dependency chain: `@sentry/nextjs` → `@sentry/webpack-plugin` → `webpack` → `terser-webpack-plugin` → `serialize-javascript@6.0.2`
- Override needed because `terser-webpack-plugin` still pins `^6.0.2` — the advisory was only published 2026-02-28
- Override can be removed once `terser-webpack-plugin` bumps to `^7.0.3`

## Test plan
- [x] `npm audit` returns 0 vulnerabilities
- [x] `npm test` passes (235 tests)