### PR TITLE
perf: add forward FK and sort indexes

### DIFF
--- a/supabase/migrations/20260302_forward_fk_and_sort_indexes.sql
+++ b/supabase/migrations/20260302_forward_fk_and_sort_indexes.sql
@@ -1,0 +1,16 @@
+-- Forward FK indexes and sort index
+--
+-- Adds indexes suggested by Supabase Index Advisor based on production query patterns:
+--   1. Forward FK indexes on junction tables (case_study_id) for detail page lookups
+--   2. Sort index on case_studies.updated_at for listing page ORDER BY
+
+-- Forward FK indexes — used when fetching relations for a specific case study
+CREATE INDEX IF NOT EXISTS idx_case_study_industry_relations_case_study_id
+  ON public.case_study_industry_relations (case_study_id);
+
+CREATE INDEX IF NOT EXISTS idx_case_study_persona_relations_case_study_id
+  ON public.case_study_persona_relations (case_study_id);
+
+-- Sort index — used by case study listing page (ORDER BY updated_at DESC)
+CREATE INDEX IF NOT EXISTS idx_case_studies_updated_at
+  ON public.case_studies (updated_at);


### PR DESCRIPTION
## Summary
- Adds indexes suggested by Supabase Index Advisor based on production query patterns
- Forward FK indexes on `case_study_industry_relations(case_study_id)` and `case_study_persona_relations(case_study_id)` for detail page lookups
- Sort index on `case_studies(updated_at)` for listing page ORDER BY (5x cost reduction per advisor)

## Test plan
- [x] Migration applied to remote database
- [x] `CREATE INDEX IF NOT EXISTS` — safe, additive, no-op if exists