### PR TITLE
refactor: extract magic numbers into shared validation constants

### DIFF
--- a/src/app/admin/algorithms/[id]/actions.ts
+++ b/src/app/admin/algorithms/[id]/actions.ts
@@ -5,17 +5,18 @@ import { fromTable } from '@/lib/supabase-untyped';
 import { revalidatePath } from 'next/cache';
 import { TablesInsert } from '@/types/supabase';
 import { z } from 'zod';
+import { MAX_NAME_LENGTH, MAX_MEDIUM_TEXT_LENGTH, MAX_CONTENT_LENGTH, MAX_LONG_TEXT_LENGTH } from '@/lib/validation/constants';
 
 const algorithmSchema = z.object({
   id: z.string().uuid().optional(),
-  name: z.string().min(1).max(500),
-  slug: z.string().min(1).max(500),
-  description: z.string().max(5000).nullable().optional(),
-  main_content: z.string().max(50000).nullable().optional(),
-  use_cases: z.string().max(10000).nullable().optional(),
+  name: z.string().min(1).max(MAX_NAME_LENGTH),
+  slug: z.string().min(1).max(MAX_NAME_LENGTH),
+  description: z.string().max(MAX_MEDIUM_TEXT_LENGTH).nullable().optional(),
+  main_content: z.string().max(MAX_CONTENT_LENGTH).nullable().optional(),
+  use_cases: z.string().max(MAX_LONG_TEXT_LENGTH).nullable().optional(),
   published: z.boolean().optional(),
-  steps: z.string().max(10000).optional(),
-  academic_references: z.string().max(10000).optional(),
+  steps: z.string().max(MAX_LONG_TEXT_LENGTH).optional(),
+  academic_references: z.string().max(MAX_LONG_TEXT_LENGTH).optional(),
   related_case_studies: z.array(z.string().uuid()).optional(),
   related_industries: z.array(z.string().uuid()).optional(),
   related_personas: z.array(z.string().uuid()).optional(),

--- a/src/app/admin/blog/[id]/actions.ts
+++ b/src/app/admin/blog/[id]/actions.ts
@@ -4,17 +4,18 @@ import { createServiceRoleSupabaseClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { TablesInsert } from '@/types/supabase';
 import { z } from 'zod';
+import { MAX_TITLE_LENGTH, MAX_MEDIUM_TEXT_LENGTH, MAX_CONTENT_LENGTH, MAX_SHORT_TEXT_LENGTH, MAX_URL_LENGTH, MAX_TAG_LIST_LENGTH } from '@/lib/validation/constants';
 
 const blogPostSchema = z.object({
   id: z.string().uuid().optional(),
-  title: z.string().min(1).max(500),
-  slug: z.string().min(1).max(500),
-  description: z.string().max(5000).nullable().optional(),
-  content: z.string().max(50000).nullable().optional(),
-  author: z.string().max(200).nullable().optional(),
-  featured_image: z.string().max(2000).nullable().optional(),
-  category: z.string().max(200).nullable().optional(),
-  tags: z.string().max(2000).nullable().optional(),
+  title: z.string().min(1).max(MAX_TITLE_LENGTH),
+  slug: z.string().min(1).max(MAX_TITLE_LENGTH),
+  description: z.string().max(MAX_MEDIUM_TEXT_LENGTH).nullable().optional(),
+  content: z.string().max(MAX_CONTENT_LENGTH).nullable().optional(),
+  author: z.string().max(MAX_SHORT_TEXT_LENGTH).nullable().optional(),
+  featured_image: z.string().max(MAX_URL_LENGTH).nullable().optional(),
+  category: z.string().max(MAX_SHORT_TEXT_LENGTH).nullable().optional(),
+  tags: z.string().max(MAX_TAG_LIST_LENGTH).nullable().optional(),
   published: z.boolean().optional(),
   featured: z.boolean().optional(),
   published_at: z.string().nullable().optional(),

--- a/src/app/admin/case-studies/[id]/actions.ts
+++ b/src/app/admin/case-studies/[id]/actions.ts
@@ -4,18 +4,19 @@ import { createServiceRoleSupabaseClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { TablesInsert } from '@/types/supabase';
 import { z } from 'zod';
+import { MAX_TITLE_LENGTH, MAX_MEDIUM_TEXT_LENGTH, MAX_CONTENT_LENGTH, MAX_LONG_TEXT_LENGTH, MIN_YEAR, MAX_YEAR } from '@/lib/validation/constants';
 
 const caseStudyActionSchema = z.object({
   id: z.string().uuid().optional(),
-  title: z.string().min(1).max(500),
-  slug: z.string().min(1).max(500),
-  description: z.string().max(5000).nullable().optional(),
-  main_content: z.string().max(50000).nullable().optional(),
+  title: z.string().min(1).max(MAX_TITLE_LENGTH),
+  slug: z.string().min(1).max(MAX_TITLE_LENGTH),
+  description: z.string().max(MAX_MEDIUM_TEXT_LENGTH).nullable().optional(),
+  main_content: z.string().max(MAX_CONTENT_LENGTH).nullable().optional(),
   published: z.boolean().optional(),
   featured: z.boolean().optional(),
-  academic_references: z.string().max(10000).nullable().optional(),
-  resource_links: z.string().max(10000).nullable().optional(),
-  year: z.number().int().min(1900).max(2100).nullable().optional(),
+  academic_references: z.string().max(MAX_LONG_TEXT_LENGTH).nullable().optional(),
+  resource_links: z.string().max(MAX_LONG_TEXT_LENGTH).nullable().optional(),
+  year: z.number().int().min(MIN_YEAR).max(MAX_YEAR).nullable().optional(),
   industries: z.array(z.string().uuid()).optional(),
   algorithms: z.array(z.string().uuid()).optional(),
   personas: z.array(z.string().uuid()).optional(),

--- a/src/app/admin/industries/[id]/actions.ts
+++ b/src/app/admin/industries/[id]/actions.ts
@@ -4,13 +4,14 @@ import { createServiceRoleSupabaseClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { TablesInsert } from '@/types/supabase';
 import { z } from 'zod';
+import { MAX_NAME_LENGTH, MAX_MEDIUM_TEXT_LENGTH, MAX_CONTENT_LENGTH } from '@/lib/validation/constants';
 
 const industrySchema = z.object({
   id: z.string().uuid().optional(),
-  name: z.string().min(1).max(500),
-  slug: z.string().min(1).max(500),
-  description: z.string().max(5000).nullable().optional(),
-  main_content: z.string().max(50000).nullable().optional(),
+  name: z.string().min(1).max(MAX_NAME_LENGTH),
+  slug: z.string().min(1).max(MAX_NAME_LENGTH),
+  description: z.string().max(MAX_MEDIUM_TEXT_LENGTH).nullable().optional(),
+  main_content: z.string().max(MAX_CONTENT_LENGTH).nullable().optional(),
   published: z.boolean().optional(),
 });
 

--- a/src/app/admin/personas/[id]/actions.ts
+++ b/src/app/admin/personas/[id]/actions.ts
@@ -4,15 +4,16 @@ import { createServiceRoleSupabaseClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { Database, TablesInsert } from '@/types/supabase';
 import { z } from 'zod';
+import { MAX_NAME_LENGTH, MAX_MEDIUM_TEXT_LENGTH, MAX_CONTENT_LENGTH, MAX_LONG_TEXT_LENGTH } from '@/lib/validation/constants';
 
 const personaSchema = z.object({
   id: z.string().uuid().optional(),
-  name: z.string().min(1).max(500),
-  slug: z.string().min(1).max(500),
-  description: z.string().max(5000).nullable().optional(),
-  expertise: z.string().max(5000).nullable().optional(),
-  main_content: z.string().max(50000).nullable().optional(),
-  recommended_reading: z.string().max(10000).nullable().optional(),
+  name: z.string().min(1).max(MAX_NAME_LENGTH),
+  slug: z.string().min(1).max(MAX_NAME_LENGTH),
+  description: z.string().max(MAX_MEDIUM_TEXT_LENGTH).nullable().optional(),
+  expertise: z.string().max(MAX_MEDIUM_TEXT_LENGTH).nullable().optional(),
+  main_content: z.string().max(MAX_CONTENT_LENGTH).nullable().optional(),
+  recommended_reading: z.string().max(MAX_LONG_TEXT_LENGTH).nullable().optional(),
   published: z.boolean().optional(),
   industry: z.array(z.string().uuid()).optional(),
 });

--- a/src/app/api/case-studies/route.ts
+++ b/src/app/api/case-studies/route.ts
@@ -13,6 +13,7 @@ import {
 import { createServiceRoleSupabaseClient } from '@/lib/supabase';
 import { fromTable } from '@/lib/supabase-untyped';
 import { caseStudySchema, formatValidationErrors } from '@/lib/validation/schemas';
+import { MAX_BULK_IDS } from '@/lib/validation/constants';
 import { requireAdmin } from '@/lib/auth';
 import type { Database } from '@/types/supabase';
 
@@ -566,7 +567,7 @@ export async function PATCH(request: NextRequest) {
     if (body.bulk) {
       const bulkSchema = z.object({
         operation: z.enum(['publish', 'unpublish', 'delete']),
-        ids: z.array(z.string().uuid()).min(1).max(100),
+        ids: z.array(z.string().uuid()).min(1).max(MAX_BULK_IDS),
       });
 
       const parsed = bulkSchema.safeParse(body);

--- a/src/lib/validation/constants.ts
+++ b/src/lib/validation/constants.ts
@@ -1,0 +1,26 @@
+// Field length limits
+export const MAX_SLUG_LENGTH = 200;
+export const MAX_TITLE_LENGTH = 500;
+export const MAX_NAME_LENGTH = 500;
+export const MAX_SHORT_TEXT_LENGTH = 200;
+export const MAX_DESCRIPTION_LENGTH = 1000;
+export const MAX_MEDIUM_TEXT_LENGTH = 5000;
+export const MAX_LONG_TEXT_LENGTH = 10000;
+export const MAX_CONTENT_LENGTH = 50000;
+export const MAX_EMAIL_LENGTH = 255;
+export const MAX_SOURCE_LENGTH = 50;
+export const MAX_URL_LENGTH = 2000;
+export const MAX_TAG_LIST_LENGTH = 2000;
+export const MAX_LABEL_LENGTH = 100;
+
+// Pagination
+export const MIN_PAGE = 1;
+export const MIN_PAGE_SIZE = 1;
+export const MAX_PAGE_SIZE = 100;
+
+// Bulk operations
+export const MAX_BULK_IDS = 100;
+
+// Year ranges
+export const MIN_YEAR = 1900;
+export const MAX_YEAR = 2100;

--- a/src/lib/validation/schemas.test.ts
+++ b/src/lib/validation/schemas.test.ts
@@ -40,13 +40,13 @@ describe('caseStudySchema', () => {
     expect(result.success).toBe(true)
   })
 
-  it('rejects year below 1990', () => {
-    const result = caseStudySchema.safeParse({ ...validCaseStudy, year: 1989 })
+  it('rejects year below 1900', () => {
+    const result = caseStudySchema.safeParse({ ...validCaseStudy, year: 1899 })
     expect(result.success).toBe(false)
   })
 
-  it('rejects year above 2030', () => {
-    const result = caseStudySchema.safeParse({ ...validCaseStudy, year: 2031 })
+  it('rejects year above 2100', () => {
+    const result = caseStudySchema.safeParse({ ...validCaseStudy, year: 2101 })
     expect(result.success).toBe(false)
   })
 

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1,27 +1,46 @@
 import { z } from 'zod';
+import {
+  MAX_SLUG_LENGTH,
+  MAX_TITLE_LENGTH,
+  MAX_SHORT_TEXT_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_MEDIUM_TEXT_LENGTH,
+  MAX_LONG_TEXT_LENGTH,
+  MAX_CONTENT_LENGTH,
+  MAX_EMAIL_LENGTH,
+  MAX_SOURCE_LENGTH,
+  MAX_URL_LENGTH,
+  MAX_LABEL_LENGTH,
+  MAX_NAME_LENGTH,
+  MIN_PAGE,
+  MIN_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MIN_YEAR,
+  MAX_YEAR,
+} from './constants';
 
 // Base validation schemas
 const slugSchema = z
   .string()
   .min(1, 'Slug is required')
-  .max(200, 'Slug must be less than 200 characters')
+  .max(MAX_SLUG_LENGTH, `Slug must be less than ${MAX_SLUG_LENGTH} characters`)
   .regex(/^[a-z0-9-]+$/, 'Slug must only contain lowercase letters, numbers, and hyphens');
 
 const titleSchema = z
   .string()
   .min(1, 'Title is required')
-  .max(500, 'Title must be less than 500 characters')
+  .max(MAX_TITLE_LENGTH, `Title must be less than ${MAX_TITLE_LENGTH} characters`)
   .trim();
 
 const descriptionSchema = z
   .string()
-  .max(1000, 'Description must be less than 1000 characters')
+  .max(MAX_DESCRIPTION_LENGTH, `Description must be less than ${MAX_DESCRIPTION_LENGTH} characters`)
   .optional()
   .nullable();
 
 const contentSchema = z
   .string()
-  .max(50000, 'Content must be less than 50,000 characters')
+  .max(MAX_CONTENT_LENGTH, `Content must be less than ${MAX_CONTENT_LENGTH.toLocaleString()} characters`)
   .optional()
   .nullable();
 
@@ -52,7 +71,7 @@ export const caseStudySchema = z.object({
   url: urlSchema,
   published: z.boolean().default(false),
   featured: z.boolean().default(false),
-  year: z.number().int().min(1990).max(2030).optional(),
+  year: z.number().int().min(MIN_YEAR).max(MAX_YEAR).optional(),
   partner_companies: stringArraySchema,
   quantum_companies: stringArraySchema,
   quantum_hardware: stringArraySchema,
@@ -60,11 +79,11 @@ export const caseStudySchema = z.object({
   algorithms: idArraySchema,
   industries: idArraySchema,
   personas: idArraySchema,
-  academic_references: z.string().max(10000, 'Academic references must be less than 10,000 characters').optional().nullable(),
+  academic_references: z.string().max(MAX_LONG_TEXT_LENGTH, `Academic references must be less than ${MAX_LONG_TEXT_LENGTH.toLocaleString()} characters`).optional().nullable(),
   resource_links: z.array(z.object({
     url: z.string().url('Must be a valid URL'),
-    title: z.string().min(1).max(200),
-    description: z.string().max(500).optional()
+    title: z.string().min(1).max(MAX_SHORT_TEXT_LENGTH),
+    description: z.string().max(MAX_NAME_LENGTH).optional() // Short description, capped at 500
   })).optional().default([])
 });
 
@@ -77,11 +96,11 @@ export const blogPostSchema = z.object({
   content: contentSchema,
   published: z.boolean().default(false),
   featured: z.boolean().default(false),
-  author: z.string().max(100, 'Author name must be less than 100 characters').optional().nullable(),
-  featured_image: z.string().max(500, 'Featured image URL must be less than 500 characters').optional().nullable(),
+  author: z.string().max(MAX_LABEL_LENGTH, `Author name must be less than ${MAX_LABEL_LENGTH} characters`).optional().nullable(),
+  featured_image: z.string().max(MAX_URL_LENGTH, `Featured image URL must be less than ${MAX_URL_LENGTH} characters`).optional().nullable(),
   published_at: z.string().datetime('Invalid date format').optional().nullable(),
   tags: stringArraySchema,
-  category: z.string().max(100, 'Category must be less than 100 characters').optional().nullable()
+  category: z.string().max(MAX_LABEL_LENGTH, `Category must be less than ${MAX_LABEL_LENGTH} characters`).optional().nullable()
 });
 
 // Algorithm validation schema
@@ -92,7 +111,7 @@ export const algorithmSchema = z.object({
   description: descriptionSchema,
   main_content: contentSchema,
   published: z.boolean().default(false),
-  quantum_advantage: z.string().max(10000, 'Quantum advantage must be less than 10,000 characters').optional().nullable(),
+  quantum_advantage: z.string().max(MAX_LONG_TEXT_LENGTH, `Quantum advantage must be less than ${MAX_LONG_TEXT_LENGTH.toLocaleString()} characters`).optional().nullable(),
   use_cases: stringArraySchema,
   complexity: z.enum(['Beginner', 'Intermediate', 'Advanced']).optional().nullable(),
   quantum_volume_required: z.number().int().min(1).optional().nullable(),
@@ -107,7 +126,7 @@ export const industrySchema = z.object({
   slug: slugSchema,
   description: descriptionSchema,
   main_content: contentSchema,
-  icon: z.string().max(100, 'Icon must be less than 100 characters').optional().nullable(),
+  icon: z.string().max(MAX_LABEL_LENGTH, `Icon must be less than ${MAX_LABEL_LENGTH} characters`).optional().nullable(),
   published: z.boolean().default(false)
 });
 
@@ -118,22 +137,22 @@ export const personaSchema = z.object({
   slug: slugSchema,
   description: descriptionSchema,
   main_content: contentSchema,
-  role: z.string().max(200, 'Role must be less than 200 characters').optional().nullable(),
+  role: z.string().max(MAX_SHORT_TEXT_LENGTH, `Role must be less than ${MAX_SHORT_TEXT_LENGTH} characters`).optional().nullable(),
   published: z.boolean().default(false),
   experience_level: z.enum(['Beginner', 'Intermediate', 'Advanced']).optional().nullable(),
-  technical_background: z.string().max(200).optional().nullable()
+  technical_background: z.string().max(MAX_SHORT_TEXT_LENGTH).optional().nullable()
 });
 
 // Newsletter subscription validation schema
 export const newsletterSubscriptionSchema = z.object({
-  email: z.string().email('Invalid email format').max(255, 'Email must be less than 255 characters'),
-  source: z.string().max(50).optional().default('website')
+  email: z.string().email('Invalid email format').max(MAX_EMAIL_LENGTH, `Email must be less than ${MAX_EMAIL_LENGTH} characters`),
+  source: z.string().max(MAX_SOURCE_LENGTH).optional().default('website')
 });
 
 // Query parameter validation schemas
 export const paginationSchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(100).default(10),
+  page: z.coerce.number().int().min(MIN_PAGE).default(1),
+  pageSize: z.coerce.number().int().min(MIN_PAGE_SIZE).max(MAX_PAGE_SIZE).default(10),
   includeUnpublished: z.coerce.boolean().default(false)
 });
 

--- a/src/utils/form-validation.ts
+++ b/src/utils/form-validation.ts
@@ -1,6 +1,8 @@
 /**
  * Types for form validation
  */
+import { MIN_YEAR, MAX_YEAR } from '@/lib/validation/constants';
+
 export type ValidationIssue = {
   name: string;
   label: string;
@@ -289,8 +291,8 @@ export function createContentValidationRules(contentType: 'algorithm' | 'persona
         {
           field: 'year',
           tab: 'basic',
-          label: 'Year must be between 1990 and 2030',
-          validator: validators.and(validators.isNumber, validators.min(1990), validators.max(2030))
+          label: `Year must be between ${MIN_YEAR} and ${MAX_YEAR}`,
+          validator: validators.and(validators.isNumber, validators.min(MIN_YEAR), validators.max(MAX_YEAR))
         },
         {
           field: 'algorithms',


### PR DESCRIPTION
## Summary
- Extract hardcoded numeric limits from validation schemas and admin actions into named constants in `src/lib/validation/constants.ts`
- Fix semantic mismatches where constants were reused across unrelated domains (`MAX_ICON_LENGTH` for author/category, `MAX_URL_LENGTH` for tags, `MAX_TITLE_LENGTH` for resource link descriptions)
- Rename `MAX_ICON_LENGTH` → `MAX_LABEL_LENGTH`, add `MAX_TAG_LIST_LENGTH`, use `MAX_NAME_LENGTH` for resource link descriptions

## Test plan
- [x] All 235 tests pass (`npm test`)
- [x] TypeScript compilation clean (`npx tsc --noEmit --skipLibCheck`)
- [ ] Verify admin CMS forms still save correctly (algorithms, blog, case studies, industries, personas)