### PR TITLE
fix: reduce Vercel ISR writes and Sentry usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **ISR Revalidation Interval**: Increased ISR safety net from 1 hour to 24 hours across all 18 pages to reduce Vercel ISR write usage (on-demand revalidation still handles CMS changes instantly)
+- **Sentry Sampling Rates**: Reduced client and edge performance trace sampling from 100% to 10% in production; disabled general session replay (error session replay remains at 100%)
+
+### Added
+- **Weekly Link Check**: Added GitHub Action (`link-check.yml`) using lychee to check for broken URLs in source files every Monday
+- **Centralized External URLs**: Created `src/lib/external-links.ts` with all Tally form and social media URLs; updated FeedbackButton, GetInvolvedSection, PrivacyContactLink, and contact page to use it
+- **Google Search Console**: Added verification meta tag placeholder in layout metadata
+
 ### Security
 - **serialize-javascript RCE** ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)): Added npm override to force `serialize-javascript@7.0.3` — fixes RCE via `RegExp.flags` and `Date.prototype.toISOString()`. Transitive dep via `@sentry/nextjs → webpack → terser-webpack-plugin`. Override can be removed once `terser-webpack-plugin` bumps from `^6.0.2` to `^7.0.3`.
 - **Database Lint Fixes**: Addressed 30 Supabase lint warnings — optimised RLS initplan evaluation, consolidated overlapping policies, hardened function `search_path`, added 12 missing FK indexes, and dropped overly permissive anon policy on `user_preferences`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ Every save/publish/unpublish action must revalidate:
 3. The individual page by slug (e.g., `/paths/algorithm/${slug}`)
 
 #### Layer 2: ISR Safety Net (fallback)
-All dynamic `[slug]/page.tsx` files export `revalidate = 3600` (1 hour). This catches **cross-entity staleness** — when a related entity changes (e.g., an algorithm's name is updated), pages that display that algorithm won't be directly revalidated by the algorithm's save action. The 1-hour ISR ensures these pages refresh eventually.
+All dynamic `[slug]/page.tsx` files export `revalidate = 86400` (24 hours). This catches **cross-entity staleness** — when a related entity changes (e.g., an algorithm's name is updated), pages that display that algorithm won't be directly revalidated by the algorithm's save action. The 24-hour ISR ensures these pages refresh eventually while keeping Vercel ISR write usage low.
 
 #### When Adding New Content Types
 1. Create admin server actions with proper `revalidatePath()` calls for save/publish/unpublish
-2. Add `export const revalidate = 3600` to the public `[slug]/page.tsx`
+2. Add `export const revalidate = 86400` to the public `[slug]/page.tsx`
 3. Use `generateStaticParams()` with `generateStaticParamsForContentType()` for build-time generation
 
 #### Request-Scoped Deduplication

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -10,7 +10,7 @@ Sentry.init({
   environment: process.env.NODE_ENV,
   
   // Performance monitoring
-  tracesSampleRate: 1.0,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
   
   debug: process.env.NODE_ENV === 'development',
 });

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,7 +19,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed tag) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
   const resolvedParams = await params;

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -6,7 +6,7 @@ import { DbBlogPost } from '@/lib/types';
 import { Clock, User } from "lucide-react";
 import { NewsletterSignup } from '@/components/ui/newsletter-signup';
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function BlogPage() {
   const posts = await getStaticContentList<DbBlogPost>('blog_posts', {

--- a/src/app/case-study/[slug]/page.tsx
+++ b/src/app/case-study/[slug]/page.tsx
@@ -69,7 +69,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed algorithm) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
   const resolvedParams = await params;

--- a/src/app/case-study/page.tsx
+++ b/src/app/case-study/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 type CaseStudy = Database['public']['Tables']['case_studies']['Row'];
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function CaseStudyPage() {
   const caseStudies = await getStaticContentList<CaseStudy>('case_studies', {

--- a/src/app/paths/algorithm/[slug]/page.tsx
+++ b/src/app/paths/algorithm/[slug]/page.tsx
@@ -82,7 +82,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed industry) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function AlgorithmPage({ params }: AlgorithmPageProps) {
   const resolvedParams = await params;

--- a/src/app/paths/algorithm/page.tsx
+++ b/src/app/paths/algorithm/page.tsx
@@ -6,7 +6,7 @@ import type { Database } from '@/types/supabase';
 
 type Algorithm = Database['public']['Tables']['algorithms']['Row'];
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function AlgorithmsPage() {
   const algorithms = await getStaticContentList('algorithms') as Algorithm[];

--- a/src/app/paths/industry/[slug]/page.tsx
+++ b/src/app/paths/industry/[slug]/page.tsx
@@ -83,7 +83,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed algorithm) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function IndustryPage({ params }: PageParams) {
   const resolvedParams = await params;

--- a/src/app/paths/industry/page.tsx
+++ b/src/app/paths/industry/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 type Industry = Database['public']['Tables']['industries']['Row'];
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function IndustriesPage() {
   const industries = await getStaticContentList('industries') as Industry[];

--- a/src/app/paths/partner-companies/[slug]/page.tsx
+++ b/src/app/paths/partner-companies/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed company) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: PartnerCompanyPageProps) {
   const resolvedParams = await params;

--- a/src/app/paths/partner-companies/page.tsx
+++ b/src/app/paths/partner-companies/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export type PartnerCompany = Database['public']['Tables']['partner_companies']['Row']
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function PartnerCompaniesPage() {
   const partnerCompanies = await getStaticContentList('partner_companies') as PartnerCompany[]

--- a/src/app/paths/persona/[slug]/page.tsx
+++ b/src/app/paths/persona/[slug]/page.tsx
@@ -80,7 +80,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed industry) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function PersonaPage({ params }: PageParams) {
   const resolvedParams = await params;

--- a/src/app/paths/persona/page.tsx
+++ b/src/app/paths/persona/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 type Persona = Database['public']['Tables']['personas']['Row'];
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function PersonasPage() {
   const personas = await getStaticContentList('personas') as Persona[];

--- a/src/app/paths/quantum-companies/[slug]/page.tsx
+++ b/src/app/paths/quantum-companies/[slug]/page.tsx
@@ -23,7 +23,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed partner) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: QuantumCompanyPageProps) {
   const resolvedParams = await params;

--- a/src/app/paths/quantum-companies/page.tsx
+++ b/src/app/paths/quantum-companies/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export type QuantumCompany = Database['public']['Tables']['quantum_companies']['Row']
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function QuantumCompaniesPage() {
   const quantumCompanies = await getStaticContentList('quantum_companies') as QuantumCompany[]

--- a/src/app/paths/quantum-hardware/[slug]/page.tsx
+++ b/src/app/paths/quantum-hardware/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed company) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: QuantumHardwarePageProps) {
   const resolvedParams = await params;

--- a/src/app/paths/quantum-hardware/page.tsx
+++ b/src/app/paths/quantum-hardware/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export type QuantumHardware = Database['public']['Tables']['quantum_hardware']['Row']
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function QuantumHardwarePage() {
   const quantumHardware = await getStaticContentList('quantum_hardware') as QuantumHardware[]

--- a/src/app/paths/quantum-software/[slug]/page.tsx
+++ b/src/app/paths/quantum-software/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateStaticParams() {
 
 // ISR safety net: on-demand revalidation handles most updates immediately,
 // but this catches cross-entity staleness (e.g. a renamed company) within 1 hour
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: QuantumSoftwarePageProps) {
   const resolvedParams = await params;

--- a/src/app/paths/quantum-software/page.tsx
+++ b/src/app/paths/quantum-software/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export type QuantumSoftware = Database['public']['Tables']['quantum_software']['Row']
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export default async function QuantumSoftwarePage() {
   const quantumSoftware = await getStaticContentList('quantum_software') as QuantumSoftware[]

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -9,10 +9,10 @@ Sentry.init({
   environment: process.env.NODE_ENV,
   
   // Performance monitoring
-  tracesSampleRate: 1.0,
-  
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+
   // Session replay configuration
-  replaysSessionSampleRate: 0.1, // Record 10% of sessions
+  replaysSessionSampleRate: 0, // Only record sessions that hit errors
   replaysOnErrorSampleRate: 1.0, // Record 100% of sessions with errors
   
   debug: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
## Summary
- Increased ISR revalidate interval from 1 hour to 24 hours across all 18 pages to reduce Vercel ISR write consumption (on-demand revalidation from CMS still handles changes instantly)
- Reduced Sentry client and edge `tracesSampleRate` from 100% to 10% in production
- Disabled general session replay (`replaysSessionSampleRate: 0`); error session replay remains at 100%

## Context
Vercel free tier alert at 75% of 200,000 ISR writes. The 1-hour ISR safety net was causing unnecessary revalidations since on-demand `revalidatePath()` already handles CMS content changes immediately.

## Test plan
- [ ] Verify Vercel deployment succeeds
- [ ] Confirm CMS save/publish still triggers immediate page updates (on-demand revalidation)
- [ ] Monitor Sentry and Vercel usage dashboards over next few days