### PR TITLE
feat: listing page pagination

### DIFF
--- a/src/app/paths/partner-companies/client.tsx
+++ b/src/app/paths/partner-companies/client.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { GridView, TableView, LayoutToggle, useLayoutPreference } from '@/components/content-list'
+import { usePagination } from '@/hooks/use-pagination'
+import { PaginationControls } from '@/components/ui/pagination-controls'
 import type { PartnerCompany } from './page'
 
 interface PartnerCompaniesClientProps {
@@ -10,8 +12,8 @@ interface PartnerCompaniesClientProps {
 
 export function PartnerCompaniesClient({ items, totalCount }: PartnerCompaniesClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
 
-  // Don't render layout toggle until client-side hydration is complete
   if (!isClient) {
     return (
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -24,10 +26,17 @@ export function PartnerCompaniesClient({ items, totalCount }: PartnerCompaniesCl
             {totalCount} partner companies available
           </div>
         </div>
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="partner-companies"
           basePath="/paths/partner-companies"
+        />
+        <PaginationControls
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -51,18 +60,26 @@ export function PartnerCompaniesClient({ items, totalCount }: PartnerCompaniesCl
       </div>
 
       {layout === 'grid' ? (
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="partner-companies"
           basePath="/paths/partner-companies"
         />
       ) : (
-        <TableView 
-          items={items}
+        <TableView
+          items={paginatedItems}
           contentType="partner-companies"
           basePath="/paths/partner-companies"
         />
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   )
 }

--- a/src/app/paths/partner-companies/client.tsx
+++ b/src/app/paths/partner-companies/client.tsx
@@ -12,7 +12,7 @@ interface PartnerCompaniesClientProps {
 
 export function PartnerCompaniesClient({ items, totalCount }: PartnerCompaniesClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items })
 
   if (!isClient) {
     return (
@@ -35,8 +35,6 @@ export function PartnerCompaniesClient({ items, totalCount }: PartnerCompaniesCl
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={goToPage}
-          hasNextPage={hasNextPage}
-          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -77,8 +75,6 @@ export function PartnerCompaniesClient({ items, totalCount }: PartnerCompaniesCl
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   )

--- a/src/app/paths/quantum-companies/client.tsx
+++ b/src/app/paths/quantum-companies/client.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { GridView, TableView, LayoutToggle, useLayoutPreference } from '@/components/content-list'
+import { usePagination } from '@/hooks/use-pagination'
+import { PaginationControls } from '@/components/ui/pagination-controls'
 import type { QuantumCompany } from './page'
 
 interface QuantumCompaniesClientProps {
@@ -10,8 +12,8 @@ interface QuantumCompaniesClientProps {
 
 export function QuantumCompaniesClient({ items, totalCount }: QuantumCompaniesClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
 
-  // Don't render layout toggle until client-side hydration is complete
   if (!isClient) {
     return (
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -24,10 +26,17 @@ export function QuantumCompaniesClient({ items, totalCount }: QuantumCompaniesCl
             {totalCount} companies available
           </div>
         </div>
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="quantum-companies"
           basePath="/paths/quantum-companies"
+        />
+        <PaginationControls
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -51,18 +60,26 @@ export function QuantumCompaniesClient({ items, totalCount }: QuantumCompaniesCl
       </div>
 
       {layout === 'grid' ? (
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="quantum-companies"
           basePath="/paths/quantum-companies"
         />
       ) : (
-        <TableView 
-          items={items}
+        <TableView
+          items={paginatedItems}
           contentType="quantum-companies"
           basePath="/paths/quantum-companies"
         />
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   )
 }

--- a/src/app/paths/quantum-companies/client.tsx
+++ b/src/app/paths/quantum-companies/client.tsx
@@ -12,7 +12,7 @@ interface QuantumCompaniesClientProps {
 
 export function QuantumCompaniesClient({ items, totalCount }: QuantumCompaniesClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items })
 
   if (!isClient) {
     return (
@@ -35,8 +35,6 @@ export function QuantumCompaniesClient({ items, totalCount }: QuantumCompaniesCl
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={goToPage}
-          hasNextPage={hasNextPage}
-          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -77,8 +75,6 @@ export function QuantumCompaniesClient({ items, totalCount }: QuantumCompaniesCl
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   )

--- a/src/app/paths/quantum-hardware/client.tsx
+++ b/src/app/paths/quantum-hardware/client.tsx
@@ -12,7 +12,7 @@ interface QuantumHardwareClientProps {
 
 export function QuantumHardwareClient({ items, totalCount }: QuantumHardwareClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items })
 
   if (!isClient) {
     return (
@@ -35,8 +35,6 @@ export function QuantumHardwareClient({ items, totalCount }: QuantumHardwareClie
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={goToPage}
-          hasNextPage={hasNextPage}
-          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -77,8 +75,6 @@ export function QuantumHardwareClient({ items, totalCount }: QuantumHardwareClie
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   )

--- a/src/app/paths/quantum-hardware/client.tsx
+++ b/src/app/paths/quantum-hardware/client.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { GridView, TableView, LayoutToggle, useLayoutPreference } from '@/components/content-list'
+import { usePagination } from '@/hooks/use-pagination'
+import { PaginationControls } from '@/components/ui/pagination-controls'
 import type { QuantumHardware } from './page'
 
 interface QuantumHardwareClientProps {
@@ -10,8 +12,8 @@ interface QuantumHardwareClientProps {
 
 export function QuantumHardwareClient({ items, totalCount }: QuantumHardwareClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
 
-  // Don't render layout toggle until client-side hydration is complete
   if (!isClient) {
     return (
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -24,10 +26,17 @@ export function QuantumHardwareClient({ items, totalCount }: QuantumHardwareClie
             {totalCount} hardware platforms available
           </div>
         </div>
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="quantum-hardware"
           basePath="/paths/quantum-hardware"
+        />
+        <PaginationControls
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -51,18 +60,26 @@ export function QuantumHardwareClient({ items, totalCount }: QuantumHardwareClie
       </div>
 
       {layout === 'grid' ? (
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="quantum-hardware"
           basePath="/paths/quantum-hardware"
         />
       ) : (
-        <TableView 
-          items={items}
+        <TableView
+          items={paginatedItems}
           contentType="quantum-hardware"
           basePath="/paths/quantum-hardware"
         />
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   )
 }

--- a/src/app/paths/quantum-software/client.tsx
+++ b/src/app/paths/quantum-software/client.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { GridView, TableView, LayoutToggle, useLayoutPreference } from '@/components/content-list'
+import { usePagination } from '@/hooks/use-pagination'
+import { PaginationControls } from '@/components/ui/pagination-controls'
 import type { QuantumSoftware } from './page'
 
 interface QuantumSoftwareClientProps {
@@ -10,8 +12,8 @@ interface QuantumSoftwareClientProps {
 
 export function QuantumSoftwareClient({ items, totalCount }: QuantumSoftwareClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
 
-  // Don't render layout toggle until client-side hydration is complete
   if (!isClient) {
     return (
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -24,10 +26,17 @@ export function QuantumSoftwareClient({ items, totalCount }: QuantumSoftwareClie
             {totalCount} software platforms available
           </div>
         </div>
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="quantum-software"
           basePath="/paths/quantum-software"
+        />
+        <PaginationControls
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -51,18 +60,26 @@ export function QuantumSoftwareClient({ items, totalCount }: QuantumSoftwareClie
       </div>
 
       {layout === 'grid' ? (
-        <GridView 
-          items={items}
+        <GridView
+          items={paginatedItems}
           contentType="quantum-software"
           basePath="/paths/quantum-software"
         />
       ) : (
-        <TableView 
-          items={items}
+        <TableView
+          items={paginatedItems}
           contentType="quantum-software"
           basePath="/paths/quantum-software"
         />
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   )
 }

--- a/src/app/paths/quantum-software/client.tsx
+++ b/src/app/paths/quantum-software/client.tsx
@@ -12,7 +12,7 @@ interface QuantumSoftwareClientProps {
 
 export function QuantumSoftwareClient({ items, totalCount }: QuantumSoftwareClientProps) {
   const { layout, toggleLayout, isClient } = useLayoutPreference('grid')
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items })
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items })
 
   if (!isClient) {
     return (
@@ -35,8 +35,6 @@ export function QuantumSoftwareClient({ items, totalCount }: QuantumSoftwareClie
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={goToPage}
-          hasNextPage={hasNextPage}
-          hasPreviousPage={hasPreviousPage}
         />
       </div>
     )
@@ -77,8 +75,6 @@ export function QuantumSoftwareClient({ items, totalCount }: QuantumSoftwareClie
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   )

--- a/src/components/AlgorithmList.tsx
+++ b/src/components/AlgorithmList.tsx
@@ -62,7 +62,7 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
       });
   }, [algorithms, searchQuery, sortBy]);
 
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredAlgorithms });
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items: filteredAlgorithms });
 
   // Memoize event handlers to prevent child re-renders
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -109,10 +109,7 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
         {/* View Switcher and Results Count Row */}
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-            {filteredAlgorithms.length === 0
-              ? '0 algorithms found'
-              : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredAlgorithms.length)} of ${filteredAlgorithms.length} algorithm${filteredAlgorithms.length !== 1 ? 's' : ''}`
-            }
+            {filteredAlgorithms.length} algorithm{filteredAlgorithms.length !== 1 ? 's' : ''} found
           </div>
           <ViewSwitcher value={viewMode} onValueChange={handleViewModeChange} />
         </div>
@@ -156,8 +153,6 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   );

--- a/src/components/AlgorithmList.tsx
+++ b/src/components/AlgorithmList.tsx
@@ -9,6 +9,8 @@ import ContentCard from '@/components/ui/content-card';
 import { ViewSwitcher } from '@/components/ui/view-switcher';
 import { useViewSwitcher } from '@/hooks/useViewSwitcher';
 import { useSortPersistence } from '@/hooks/useSortPersistence';
+import { usePagination } from '@/hooks/use-pagination';
+import { PaginationControls } from '@/components/ui/pagination-controls';
 import { getContentMetadata } from '@/lib/content-metadata';
 
 type Algorithm = Database['public']['Tables']['algorithms']['Row'];
@@ -60,6 +62,8 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
       });
   }, [algorithms, searchQuery, sortBy]);
 
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredAlgorithms });
+
   // Memoize event handlers to prevent child re-renders
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
@@ -105,7 +109,10 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
         {/* View Switcher and Results Count Row */}
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-            {filteredAlgorithms.length} algorithm{filteredAlgorithms.length !== 1 ? 's' : ''} found
+            {filteredAlgorithms.length === 0
+              ? '0 algorithms found'
+              : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredAlgorithms.length)} of ${filteredAlgorithms.length} algorithm${filteredAlgorithms.length !== 1 ? 's' : ''}`
+            }
           </div>
           <ViewSwitcher value={viewMode} onValueChange={handleViewModeChange} />
         </div>
@@ -116,7 +123,7 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
         ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
         : "space-y-4"
       }>
-        {filteredAlgorithms.map((algorithm) => {
+        {paginatedItems.map((algorithm) => {
           // Get metadata using the new system
           const metadata = getContentMetadata('algorithms', algorithm, viewMode);
           
@@ -144,6 +151,14 @@ export default function AlgorithmList({ algorithms }: AlgorithmListProps) {
           </p>
         </div>
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   );
 } 

--- a/src/components/CaseStudiesList.tsx
+++ b/src/components/CaseStudiesList.tsx
@@ -9,6 +9,8 @@ import ContentCard from '@/components/ui/content-card';
 import { ViewSwitcher } from '@/components/ui/view-switcher';
 import { useViewSwitcher } from '@/hooks/useViewSwitcher';
 import { useSortPersistence } from '@/hooks/useSortPersistence';
+import { usePagination } from '@/hooks/use-pagination';
+import { PaginationControls } from '@/components/ui/pagination-controls';
 import { getContentMetadata } from '@/lib/content-metadata';
 import { FacetedFilters } from '@/components/FacetedFilters';
 import type { FilterGroup } from '@/components/FacetedFilters';
@@ -94,6 +96,8 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
         }
       });
   }, [caseStudies, searchQuery, activeFilters, sortBy, relationshipMap]);
+
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredCaseStudies });
 
   // Compute cross-filtered counts for sidebar
   const filterGroups: FilterGroup[] = useMemo(() => {
@@ -263,7 +267,10 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
           <div className="flex items-center justify-between flex-wrap gap-2">
             <div className="flex items-center gap-2 flex-wrap">
               <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-                {filteredCaseStudies.length} case stud{filteredCaseStudies.length !== 1 ? 'ies' : 'y'} found
+                {filteredCaseStudies.length === 0
+                  ? '0 case studies found'
+                  : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredCaseStudies.length)} of ${filteredCaseStudies.length} case stud${filteredCaseStudies.length !== 1 ? 'ies' : 'y'}`
+                }
               </div>
               {hasActiveFilters && (
                 <>
@@ -295,7 +302,7 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
           ? "grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"
           : "space-y-4"
         }>
-          {filteredCaseStudies.map((caseStudy) => {
+          {paginatedItems.map((caseStudy) => {
             const metadata = getContentMetadata('case-studies', caseStudy, viewMode);
             const rels = relationshipMap[caseStudy.id];
             const badges = rels
@@ -325,6 +332,14 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
             </p>
           </div>
         )}
+
+        <PaginationControls
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
+        />
       </div>
     </div>
   );

--- a/src/components/CaseStudiesList.tsx
+++ b/src/components/CaseStudiesList.tsx
@@ -97,7 +97,7 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
       });
   }, [caseStudies, searchQuery, activeFilters, sortBy, relationshipMap]);
 
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredCaseStudies });
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items: filteredCaseStudies });
 
   // Compute cross-filtered counts for sidebar
   const filterGroups: FilterGroup[] = useMemo(() => {
@@ -267,10 +267,7 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
           <div className="flex items-center justify-between flex-wrap gap-2">
             <div className="flex items-center gap-2 flex-wrap">
               <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-                {filteredCaseStudies.length === 0
-                  ? '0 case studies found'
-                  : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredCaseStudies.length)} of ${filteredCaseStudies.length} case stud${filteredCaseStudies.length !== 1 ? 'ies' : 'y'}`
-                }
+                {filteredCaseStudies.length} case stud{filteredCaseStudies.length !== 1 ? 'ies' : 'y'} found
               </div>
               {hasActiveFilters && (
                 <>
@@ -337,8 +334,6 @@ export function CaseStudiesList({ caseStudies, relationshipMap = {} }: CaseStudi
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={goToPage}
-          hasNextPage={hasNextPage}
-          hasPreviousPage={hasPreviousPage}
         />
       </div>
     </div>

--- a/src/components/IndustryList.tsx
+++ b/src/components/IndustryList.tsx
@@ -9,6 +9,8 @@ import ContentCard from '@/components/ui/content-card';
 import { ViewSwitcher } from '@/components/ui/view-switcher';
 import { useViewSwitcher } from '@/hooks/useViewSwitcher';
 import { useSortPersistence } from '@/hooks/useSortPersistence';
+import { usePagination } from '@/hooks/use-pagination';
+import { PaginationControls } from '@/components/ui/pagination-controls';
 import { getContentMetadata } from '@/lib/content-metadata';
 
 // Use the exact Industry type from Database
@@ -68,6 +70,8 @@ export default function IndustryList({ industries }: IndustryListProps) {
       }
     });
   }, [industries, sectorFilter, searchQuery, sortBy]);
+
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredIndustries });
 
   // Memoize event handlers to prevent child re-renders
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -137,7 +141,10 @@ export default function IndustryList({ industries }: IndustryListProps) {
         {/* View Switcher and Results Count Row */}
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-            {filteredIndustries.length} industr{filteredIndustries.length !== 1 ? 'ies' : 'y'} found
+            {filteredIndustries.length === 0
+              ? '0 industries found'
+              : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredIndustries.length)} of ${filteredIndustries.length} industr${filteredIndustries.length !== 1 ? 'ies' : 'y'}`
+            }
           </div>
           <ViewSwitcher value={viewMode} onValueChange={handleViewModeChange} />
         </div>
@@ -148,7 +155,7 @@ export default function IndustryList({ industries }: IndustryListProps) {
         ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
         : "space-y-4"
       }>
-        {filteredIndustries.map((industry) => {
+        {paginatedItems.map((industry) => {
           // Get metadata using the new system
           const metadata = getContentMetadata('industries', industry, viewMode);
           
@@ -176,6 +183,14 @@ export default function IndustryList({ industries }: IndustryListProps) {
           </p>
         </div>
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   );
 } 

--- a/src/components/IndustryList.tsx
+++ b/src/components/IndustryList.tsx
@@ -71,7 +71,7 @@ export default function IndustryList({ industries }: IndustryListProps) {
     });
   }, [industries, sectorFilter, searchQuery, sortBy]);
 
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredIndustries });
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items: filteredIndustries });
 
   // Memoize event handlers to prevent child re-renders
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -141,10 +141,7 @@ export default function IndustryList({ industries }: IndustryListProps) {
         {/* View Switcher and Results Count Row */}
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-            {filteredIndustries.length === 0
-              ? '0 industries found'
-              : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredIndustries.length)} of ${filteredIndustries.length} industr${filteredIndustries.length !== 1 ? 'ies' : 'y'}`
-            }
+            {filteredIndustries.length} industr{filteredIndustries.length !== 1 ? 'ies' : 'y'} found
           </div>
           <ViewSwitcher value={viewMode} onValueChange={handleViewModeChange} />
         </div>
@@ -188,8 +185,6 @@ export default function IndustryList({ industries }: IndustryListProps) {
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   );

--- a/src/components/PersonaList.tsx
+++ b/src/components/PersonaList.tsx
@@ -9,6 +9,8 @@ import ContentCard from '@/components/ui/content-card';
 import { ViewSwitcher } from '@/components/ui/view-switcher';
 import { useViewSwitcher } from '@/hooks/useViewSwitcher';
 import { useSortPersistence } from '@/hooks/useSortPersistence';
+import { usePagination } from '@/hooks/use-pagination';
+import { PaginationControls } from '@/components/ui/pagination-controls';
 import { getContentMetadata } from '@/lib/content-metadata';
 
 // Explicitly import the Row type
@@ -62,6 +64,8 @@ export default function PersonaList({ personas }: PersonaListProps) {
     });
   }, [personas, searchQuery, sortBy]);
 
+  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredPersonas });
+
   // Memoize event handlers to prevent child re-renders
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
@@ -107,7 +111,10 @@ export default function PersonaList({ personas }: PersonaListProps) {
         {/* View Switcher and Results Count Row */}
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-            {filteredPersonas.length} persona{filteredPersonas.length !== 1 ? 's' : ''} found
+            {filteredPersonas.length === 0
+              ? '0 personas found'
+              : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredPersonas.length)} of ${filteredPersonas.length} persona${filteredPersonas.length !== 1 ? 's' : ''}`
+            }
           </div>
           <ViewSwitcher value={viewMode} onValueChange={handleViewModeChange} />
         </div>
@@ -118,7 +125,7 @@ export default function PersonaList({ personas }: PersonaListProps) {
         ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
         : "space-y-4"
       }>
-        {filteredPersonas.map((persona) => {
+        {paginatedItems.map((persona) => {
           // Get metadata using the new system
           const metadata = getContentMetadata('personas', persona, viewMode);
           
@@ -146,6 +153,14 @@ export default function PersonaList({ personas }: PersonaListProps) {
           </p>
         </div>
       )}
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={goToPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
     </div>
   );
 } 

--- a/src/components/PersonaList.tsx
+++ b/src/components/PersonaList.tsx
@@ -64,7 +64,7 @@ export default function PersonaList({ personas }: PersonaListProps) {
     });
   }, [personas, searchQuery, sortBy]);
 
-  const { currentPage, totalPages, paginatedItems, goToPage, hasNextPage, hasPreviousPage } = usePagination({ items: filteredPersonas });
+  const { currentPage, totalPages, paginatedItems, goToPage } = usePagination({ items: filteredPersonas });
 
   // Memoize event handlers to prevent child re-renders
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -111,10 +111,7 @@ export default function PersonaList({ personas }: PersonaListProps) {
         {/* View Switcher and Results Count Row */}
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground" aria-live="polite" aria-atomic="true">
-            {filteredPersonas.length === 0
-              ? '0 personas found'
-              : `Showing ${(currentPage - 1) * 12 + 1}–${Math.min(currentPage * 12, filteredPersonas.length)} of ${filteredPersonas.length} persona${filteredPersonas.length !== 1 ? 's' : ''}`
-            }
+            {filteredPersonas.length} persona{filteredPersonas.length !== 1 ? 's' : ''} found
           </div>
           <ViewSwitcher value={viewMode} onValueChange={handleViewModeChange} />
         </div>
@@ -158,8 +155,6 @@ export default function PersonaList({ personas }: PersonaListProps) {
         currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={goToPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
       />
     </div>
   );

--- a/src/components/ui/pagination-controls.tsx
+++ b/src/components/ui/pagination-controls.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+function getPageNumbers(
+  currentPage: number,
+  totalPages: number,
+): (number | "ellipsis")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const pages: (number | "ellipsis")[] = [1];
+
+  if (currentPage > 3) {
+    pages.push("ellipsis");
+  }
+
+  const start = Math.max(2, currentPage - 1);
+  const end = Math.min(totalPages - 1, currentPage + 1);
+
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+
+  if (currentPage < totalPages - 2) {
+    pages.push("ellipsis");
+  }
+
+  pages.push(totalPages);
+
+  return pages;
+}
+
+export function PaginationControls({
+  currentPage,
+  totalPages,
+  onPageChange,
+  hasNextPage,
+  hasPreviousPage,
+}: PaginationControlsProps) {
+  if (totalPages <= 1) return null;
+
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
+
+  return (
+    <nav
+      className="flex items-center justify-center gap-1 mt-8 border-b-0"
+      role="navigation"
+      aria-label="Pagination"
+    >
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={!hasPreviousPage}
+        aria-label="Go to previous page"
+        className="hover:bg-primary/10 hover:border-primary hover:text-primary"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      {pageNumbers.map((page, index) =>
+        page === "ellipsis" ? (
+          <span
+            key={`ellipsis-${index}`}
+            className="px-2 text-sm text-muted-foreground"
+            aria-hidden="true"
+          >
+            …
+          </span>
+        ) : (
+          <Button
+            key={page}
+            variant={page === currentPage ? "default" : "outline"}
+            size="sm"
+            onClick={() => onPageChange(page)}
+            aria-label={`Go to page ${page}`}
+            aria-current={page === currentPage ? "page" : undefined}
+            className={
+              page === currentPage
+                ? "w-9"
+                : "w-9 hover:bg-primary/10 hover:border-primary hover:text-primary"
+            }
+          >
+            {page}
+          </Button>
+        ),
+      )}
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={!hasNextPage}
+        aria-label="Go to next page"
+        className="hover:bg-primary/10 hover:border-primary hover:text-primary"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </nav>
+  );
+}

--- a/src/components/ui/pagination-controls.tsx
+++ b/src/components/ui/pagination-controls.tsx
@@ -7,8 +7,6 @@ interface PaginationControlsProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
 }
 
 function getPageNumbers(
@@ -45,10 +43,11 @@ export function PaginationControls({
   currentPage,
   totalPages,
   onPageChange,
-  hasNextPage,
-  hasPreviousPage,
 }: PaginationControlsProps) {
   if (totalPages <= 1) return null;
+
+  const hasPreviousPage = currentPage > 1;
+  const hasNextPage = currentPage < totalPages;
 
   const pageNumbers = getPageNumbers(currentPage, totalPages);
 

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useRef } from "react";
+import { useState, useMemo } from "react";
 
 interface UsePaginationProps<T> {
   items: T[];
@@ -12,10 +12,6 @@ interface UsePaginationReturn<T> {
   totalPages: number;
   paginatedItems: T[];
   goToPage: (page: number) => void;
-  goToNextPage: () => void;
-  goToPreviousPage: () => void;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
 }
 
 export function usePagination<T>({
@@ -23,11 +19,10 @@ export function usePagination<T>({
   pageSize = 12,
 }: UsePaginationProps<T>): UsePaginationReturn<T> {
   const [currentPage, setCurrentPage] = useState(1);
-  const prevItemsRef = useRef(items);
+  const [prevItems, setPrevItems] = useState(items);
 
-  // Reset to page 1 when items change
-  if (prevItemsRef.current !== items) {
-    prevItemsRef.current = items;
+  if (prevItems !== items) {
+    setPrevItems(items);
     if (currentPage !== 1) {
       setCurrentPage(1);
     }
@@ -52,9 +47,5 @@ export function usePagination<T>({
     totalPages,
     paginatedItems,
     goToPage,
-    goToNextPage: () => goToPage(currentPage + 1),
-    goToPreviousPage: () => goToPage(currentPage - 1),
-    hasNextPage: currentPage < totalPages,
-    hasPreviousPage: currentPage > 1,
   };
 }

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useMemo, useRef } from "react";
+
+interface UsePaginationProps<T> {
+  items: T[];
+  pageSize?: number;
+}
+
+interface UsePaginationReturn<T> {
+  currentPage: number;
+  totalPages: number;
+  paginatedItems: T[];
+  goToPage: (page: number) => void;
+  goToNextPage: () => void;
+  goToPreviousPage: () => void;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export function usePagination<T>({
+  items,
+  pageSize = 12,
+}: UsePaginationProps<T>): UsePaginationReturn<T> {
+  const [currentPage, setCurrentPage] = useState(1);
+  const prevItemsRef = useRef(items);
+
+  // Reset to page 1 when items change
+  if (prevItemsRef.current !== items) {
+    prevItemsRef.current = items;
+    if (currentPage !== 1) {
+      setCurrentPage(1);
+    }
+  }
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(items.length / pageSize)),
+    [items.length, pageSize],
+  );
+
+  const paginatedItems = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+  }, [items, currentPage, pageSize]);
+
+  const goToPage = (page: number) => {
+    setCurrentPage(Math.min(Math.max(1, page), totalPages));
+  };
+
+  return {
+    currentPage,
+    totalPages,
+    paginatedItems,
+    goToPage,
+    goToNextPage: () => goToPage(currentPage + 1),
+    goToPreviousPage: () => goToPage(currentPage - 1),
+    hasNextPage: currentPage < totalPages,
+    hasPreviousPage: currentPage > 1,
+  };
+}


### PR DESCRIPTION
## Summary
- Added pagination to all listing pages (Case Studies + Related Content listings)
- Loads 12 items per page
- Includes controls for incrementing/decrementing page, jumping to specific page within 7-page range

## Related Issue
Fixes #187 

## Changes Made
- Created use-pagination hook to handle page management
- Created PaginationControls component providing interactable UI for pagination
- Integrated PaginationControls components into all client-side listing pages

## Testing
Verified pagination appearance consistency through manual testing. Verified control functionality for two pages using mock data and manual testing. Verified that no errors were introduced through running the linter.