### PR TITLE
fix(admin): align quantum hardware form with CMS schema

### DIFF
--- a/src/app/admin/quantum-hardware/[id]/client.tsx
+++ b/src/app/admin/quantum-hardware/[id]/client.tsx
@@ -30,12 +30,14 @@ export function QuantumHardwareForm({ quantumHardware, caseStudies, isNew }: Qua
     slug: quantumHardware?.slug || '',
     description: quantumHardware?.description || '',
     main_content: quantumHardware?.main_content || '',
-    manufacturer: quantumHardware?.manufacturer || '',
-    qubit_count: quantumHardware?.qubit_count || '',
-    qubit_type: quantumHardware?.qubit_type || '',
+    vendor: quantumHardware?.vendor || '',
+    technology_type: quantumHardware?.technology_type || '',
+    qubit_count: quantumHardware?.qubit_count ?? '',
     coherence_time: quantumHardware?.coherence_time || '',
-    gate_fidelity: quantumHardware?.gate_fidelity || '',
-    operating_temperature: quantumHardware?.operating_temperature || '',
+    gate_fidelity: quantumHardware?.gate_fidelity ?? '',
+    connectivity: quantumHardware?.connectivity || '',
+    availability: quantumHardware?.availability || '',
+    access_model: quantumHardware?.access_model || '',
     website_url: quantumHardware?.website_url || '',
     documentation_url: quantumHardware?.documentation_url || '',
     published: quantumHardware?.published || false,
@@ -236,15 +238,27 @@ export function QuantumHardwareForm({ quantumHardware, caseStudies, isNew }: Qua
               />
             </div>
 
-            <div>
-              <Label htmlFor="manufacturer">Manufacturer</Label>
-              <Input
-                id="manufacturer"
-                value={values.manufacturer}
-                onChange={(e) => handleChange('manufacturer', e.target.value)}
-                placeholder="Company or organization"
-                className="mt-1"
-              />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <Label htmlFor="vendor">Vendor</Label>
+                <Input
+                  id="vendor"
+                  value={values.vendor}
+                  onChange={(e) => handleChange('vendor', e.target.value)}
+                  placeholder="Company or organization"
+                  className="mt-1"
+                />
+              </div>
+              <div>
+                <Label htmlFor="technology_type">Technology Type</Label>
+                <Input
+                  id="technology_type"
+                  value={values.technology_type}
+                  onChange={(e) => handleChange('technology_type', e.target.value)}
+                  placeholder="e.g., Superconducting"
+                  className="mt-1"
+                />
+              </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -259,16 +273,6 @@ export function QuantumHardwareForm({ quantumHardware, caseStudies, isNew }: Qua
                 />
               </div>
               <div>
-                <Label htmlFor="qubit_type">Qubit Type</Label>
-                <Input
-                  id="qubit_type"
-                  value={values.qubit_type}
-                  onChange={(e) => handleChange('qubit_type', e.target.value)}
-                  placeholder="e.g., Superconducting"
-                  className="mt-1"
-                />
-              </div>
-              <div>
                 <Label htmlFor="coherence_time">Coherence Time</Label>
                 <Input
                   id="coherence_time"
@@ -278,26 +282,46 @@ export function QuantumHardwareForm({ quantumHardware, caseStudies, isNew }: Qua
                   className="mt-1"
                 />
               </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <Label htmlFor="gate_fidelity">Gate Fidelity</Label>
+                <Label htmlFor="gate_fidelity">Gate Fidelity (%)</Label>
                 <Input
                   id="gate_fidelity"
                   value={values.gate_fidelity}
                   onChange={(e) => handleChange('gate_fidelity', e.target.value)}
-                  placeholder="e.g., 99.5%"
+                  placeholder="e.g., 99.5"
+                  className="mt-1"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div>
+                <Label htmlFor="connectivity">Connectivity</Label>
+                <Input
+                  id="connectivity"
+                  value={values.connectivity}
+                  onChange={(e) => handleChange('connectivity', e.target.value)}
+                  placeholder="e.g., All-to-all"
                   className="mt-1"
                 />
               </div>
               <div>
-                <Label htmlFor="operating_temperature">Operating Temperature</Label>
+                <Label htmlFor="availability">Reported Availability</Label>
                 <Input
-                  id="operating_temperature"
-                  value={values.operating_temperature}
-                  onChange={(e) => handleChange('operating_temperature', e.target.value)}
-                  placeholder="e.g., 15 mK"
+                  id="availability"
+                  value={values.availability}
+                  onChange={(e) => handleChange('availability', e.target.value)}
+                  placeholder="e.g., IonQ Cloud"
+                  className="mt-1"
+                />
+              </div>
+              <div>
+                <Label htmlFor="access_model">Access Model</Label>
+                <Input
+                  id="access_model"
+                  value={values.access_model}
+                  onChange={(e) => handleChange('access_model', e.target.value)}
+                  placeholder="e.g., Cloud API"
                   className="mt-1"
                 />
               </div>

--- a/src/app/admin/quantum-hardware/client.tsx
+++ b/src/app/admin/quantum-hardware/client.tsx
@@ -92,8 +92,8 @@ export function QuantumHardwareClient({ data }: QuantumHardwareClientProps) {
       header: 'Name',
     },
     {
-      accessorKey: 'manufacturer',
-      header: 'Manufacturer',
+      accessorKey: 'vendor',
+      header: 'Vendor',
     },
     {
       accessorKey: 'published',

--- a/src/cms/types/quantum-hardware.ts
+++ b/src/cms/types/quantum-hardware.ts
@@ -18,6 +18,7 @@ export const quantumHardware = defineContentType({
     { name: 'gate_fidelity', type: 'number' },
     { name: 'coherence_time', type: 'text' },
     { name: 'availability', type: 'text' },
+    { name: 'access_model', type: 'text' },
     { name: 'documentation_url', type: 'url' },
     { name: 'website_url', type: 'url' },
   ],

--- a/src/components/content-list/grid-view.tsx
+++ b/src/components/content-list/grid-view.tsx
@@ -23,8 +23,8 @@ interface QuantumSoftware extends BaseContentItem {
 }
 
 interface QuantumHardware extends BaseContentItem {
-  manufacturer?: string | null
-  hardware_type?: string | null
+  vendor?: string | null
+  technology_type?: string | null
 }
 
 interface QuantumCompany extends BaseContentItem {
@@ -50,7 +50,7 @@ function getSecondaryInfo(item: ContentItem, contentType: string) {
     case 'quantum-software':
       return (item as QuantumSoftware).vendor
     case 'quantum-hardware':
-      return (item as QuantumHardware).manufacturer
+      return (item as QuantumHardware).vendor
     case 'quantum-companies':
     case 'partner-companies':
       return (item as QuantumCompany | PartnerCompany).industry
@@ -70,7 +70,7 @@ function getBadges(item: ContentItem, contentType: string) {
       break
     case 'quantum-hardware':
       const hardware = item as QuantumHardware
-      if (hardware.hardware_type) badges.push(hardware.hardware_type)
+      if (hardware.technology_type) badges.push(hardware.technology_type)
       break
     case 'quantum-companies':
       const qCompany = item as QuantumCompany

--- a/src/components/content-list/table-view.tsx
+++ b/src/components/content-list/table-view.tsx
@@ -32,8 +32,8 @@ interface QuantumSoftware extends BaseContentItem {
 }
 
 interface QuantumHardware extends BaseContentItem {
-  manufacturer?: string | null
-  hardware_type?: string | null
+  vendor?: string | null
+  technology_type?: string | null
 }
 
 interface QuantumCompany extends BaseContentItem {
@@ -62,7 +62,7 @@ function getSecondaryInfo(item: ContentItem, contentType: string) {
     case 'quantum-software':
       return (item as QuantumSoftware).vendor || 'Unknown'
     case 'quantum-hardware':
-      return (item as QuantumHardware).manufacturer || 'Unknown'
+      return (item as QuantumHardware).vendor || 'Unknown'
     case 'quantum-companies':
     case 'partner-companies':
       return (item as QuantumCompany | PartnerCompany).industry || 'Various'
@@ -76,7 +76,7 @@ function getSecondaryLabel(contentType: string) {
     case 'quantum-software':
       return 'Vendor'
     case 'quantum-hardware':
-      return 'Manufacturer'
+      return 'Vendor'
     case 'quantum-companies':
     case 'partner-companies':
       return 'Industry'
@@ -100,7 +100,7 @@ export function TableView({ items, contentType, basePath }: TableViewProps) {
   }
 
   const filteredAndSortedItems = useMemo(() => {
-    let filtered = items.filter(item =>
+    const filtered = items.filter(item =>
       item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
       item.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       getSecondaryInfo(item, contentType).toLowerCase().includes(searchTerm.toLowerCase())


### PR DESCRIPTION
## Summary
Fixes quantum hardware admin and list views that used legacy field names (manufacturer, hardware_type) instead of the CMS/database-used field names (vendor, technology_type). The mismatch caused saves to drop data, leading hardware entries to not render certain fields. Also adds missing catalog fields to the admin form (availability, connectivity). 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Changes Made
- Renamed admin form fields: manufacturer -> vendor, qubit_type -> technology_type; removed operating_temperature (not stored in database)
- Added admin inputs for connectivity, availability, and access_model
- Registered access_model in the CMS content type
- Updated admin list table and public grid/table views to use vendor and technology_type

## Testing
Testing was done manually:
- Edited vendor/technology type and saved, values displayed on hardware entries
- Edited availability, connectivity, and access_model and saved, values displayed on hardware entries
- Admin list shows vendor column for rows with vendor set

## Follow-up
- There are some errors with input validation on the admin form (for instance, numeric values entered into qubit_count and gate_fidelity throw errors upon save). Centralize optional-field normalization ('' -> null, numeric coercion) in cms/schema.ts.
- Consider technology_type as a modality dropdown via CMS select + registry instead of a textbox (no DB migration required).